### PR TITLE
Create mark-deployed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier --check .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "mark-deployed": "git tag -f deployed && git push origin deployed -f"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
  - Add npm script to mark deployments with moving git tag
  - Run `npm run mark-deployed` to tag current commit as deployed and push to origin

  ## Test plan
  - [x] Verify script moves `deployed` tag to current commit
  - [x] Confirm tag is pushed to GitHub correctly